### PR TITLE
Add set_num_threads and get_num_threads

### DIFF
--- a/src/TBLIS.jl
+++ b/src/TBLIS.jl
@@ -23,6 +23,17 @@ function __init__()
     end
 end
 
+function set_num_threads(n)
+    tblis_set_num_threads = dlsym(tblis, :tblis_set_num_threads)
+    ccall(tblis_set_num_threads, Cvoid, (Cuint,), n)
+    return nothing
+end
+
+function get_num_threads()
+    tblis_get_num_threads = dlsym(tblis, :tblis_get_num_threads)
+    return ccall(tblis_get_num_threads, Cint, ())
+end
+
 
 include("TTensor.jl")
 include("Ops.jl")

--- a/test/test1.jl
+++ b/test/test1.jl
@@ -29,3 +29,18 @@ TBLIS.add!(WmBeJ,T2,"ijab","ijab")
 
 @test T2.data ≈ C
 @test isapprox(_B,C,rtol=1E-10)
+
+@testset "Test changing the number of TBLIS threads" begin
+  tblis_num_threads = TBLIS.get_num_threads()
+
+  TBLIS.set_num_threads(4)
+  @test TBLIS.get_num_threads() == 4
+
+  TBLIS.set_num_threads(1)
+  @test TBLIS.get_num_threads() == 1
+
+  # Set the number of TBLIS threads back to the original value
+  TBLIS.set_num_threads(tblis_num_threads)
+  @test TBLIS.get_num_threads() == tblis_num_threads
+end
+


### PR DESCRIPTION
Thanks for your work on making a Julia wrapper for TBLIS! We are looking forward to trying it out in [ITensors.jl](https://github.com/ITensor/ITensors.jl).

This adds the unexported functions `TBLIS.set_num_threads(n)` (to set the number of TBLIS threads to `n`) and `TBLIS.get_num_threads()` to get the current number of TBLIS threads, so the user doesn't have to set the number of threads with the environment variable.

Cheers,
Matt