### PR TITLE
Fixing `mul!` conflict

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1,4 +1,4 @@
-function mul!(C::T,A::T,B::T,idx_A::String,idx_B::String,idx_C::String;nt=C_NULL) where T <: TTensor{T2} where T2 <: AbstractFloat
+function mul!(C::T, A::T, B::T, idx_A::String, idx_B::String, idx_C::String; nt=C_NULL) where T <: TTensor{T2} where T2 <: AbstractFloat
     tblis_tmul = dlsym(tblis,:tblis_tensor_mult)
     ccall(tblis_tmul,Cvoid,(Ptr{Nothing},Ptr{Nothing},
                             Ref{TTensor{T2}},Cstring,
@@ -11,7 +11,7 @@ function mul!(C::T,A::T,B::T,idx_A::String,idx_B::String,idx_C::String;nt=C_NULL
           C,idx_C)
 end
 
-function add!(A::T,B::T,idx_A::String,idx_B::String) where T <: TTensor{T2} where T2 <: AbstractFloat
+function add!(A::T, B::T, idx_A::String, idx_B::String) where T <: TTensor{T2} where T2 <: AbstractFloat
     tblis_tadd = dlsym(tblis,:tblis_tensor_add)
     ccall(tblis_tadd,Cvoid,(Ptr{Nothing},Ptr{Nothing},
                             Ref{TTensor{T2}},Cstring,

--- a/src/TBLIS.jl
+++ b/src/TBLIS.jl
@@ -5,6 +5,8 @@ using LinearAlgebra
 using Hwloc_jll
 using tblis_jll
 
+import LinearAlgebra: mul!
+
 export TTensor
 export mul!
 export add!
@@ -24,9 +26,12 @@ function __init__()
 end
 
 function set_num_threads(n)
+    # Previous number of Threads to be returned
+    original = get_num_threads()
+
     tblis_set_num_threads = dlsym(tblis, :tblis_set_num_threads)
     ccall(tblis_set_num_threads, Cvoid, (Cuint,), n)
-    return nothing
+    return original
 end
 
 function get_num_threads()


### PR DESCRIPTION
`import LinearAlgebra: mul!` fixes the conflict when TBLIS is imported.

`set_num_threads` returns the original number of threads. 